### PR TITLE
Automatically enable Livereload in development

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -72,7 +72,7 @@ class Configuration implements ConfigurationInterface
     private function addLivereloadSection()
     {
         return $this->createRoot('livereload')
-            ->canBeEnabled()
+            ->canBeDisabled()
             ->children()
                 ->scalarNode('url')
                     ->defaultValue('//localhost:35729/livereload.js')

--- a/EventListener/InjectLiveReloadListener.php
+++ b/EventListener/InjectLiveReloadListener.php
@@ -6,7 +6,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class LiveReloadListener implements EventSubscriberInterface
+class InjectLiveReloadListener implements EventSubscriberInterface
 {
     private $url;
 
@@ -17,17 +17,20 @@ class LiveReloadListener implements EventSubscriberInterface
 
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        if (!$this->shouldInject($event)) {
+            return;
+        }
+
         $response = $event->getResponse();
         $content = $response->getContent();
-        $pos = strripos($content, '</body>');
 
+        $pos = strripos($content, '</body>');
         if (false === $pos) {
             return;
         }
 
         $script = '<script src="'.$this->url.'"></script>';
-        $content = substr($content, 0, $pos).$script.substr($content, $pos);
-        $response->setContent($content);
+        $response->setContent(substr($content, 0, $pos).$script.substr($content, $pos));
     }
 
     public static function getSubscribedEvents()
@@ -35,5 +38,18 @@ class LiveReloadListener implements EventSubscriberInterface
         return array(
             KernelEvents::RESPONSE => array('onKernelResponse', -128),
         );
+    }
+
+    private function shouldInject($event)
+    {
+        if (!$event->isMasterRequest()) {
+            return false;
+        }
+
+        if ($event->getRequest()->isXmlHttpRequest()) {
+            return false;
+        }
+
+        return $event->getResponse()->headers->has('X-Debug-Token');
     }
 }

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you decide to use this bundle, please consider opening issues if:
 * [Referencing assets](#referencing-assets)
 * [Using Bower](#using-bower)
 * [Deployment](#deployment)
+* [Livereload](#livereload)
 
 # Setup
 ## Installation
@@ -110,31 +111,6 @@ rj_frontend:
 ```
 
 For information on why this is needed see [Overriding the default package](#overriding-the-default-asset-package).
-
-## Enabling Livereload
-Enabling Livereload is as simple as:
-```yml
-# app/config/config_dev.yml
-rj_frontend:
-    livereload: true
-```
-> Make sure you enable Livereload only when in development by adding the configuration to `app/config/config_dev.yml`.
-
-With Livereload enabled, all the requests that return an HTML response with a closing `body` tag will have the following injected into the HTML, right before `</body>`:
-
-```html
-<script src="//localhost:35729/livereload.js"></script>
-```
-
-If, for some reason, you need to change the URL, you can do so with the following configuration:
-
-```yml
-# app/config/config_dev.yml
-rj_frontend:
-    livereload:
-        enabled: true
-        url: //example.com:1234/livereload.js
-```
 
 ## Setting up the asset pipeline
 A console command is provided that allows you to generate a `gulpfile.js` tailored for your project. The command will ask you a set of questions (Where are your source assets? Where should the compiled assets be placed? Which CSS pre-processor you wish to use? Etc.) and use your answers to generate the `gulpfile.js`.
@@ -561,6 +537,31 @@ var config = {
   urlPrefix: '//cdn.example.com',
   ...
 };
+```
+
+# Livereload
+> Livereload is enabled by default in development and disabled in production.
+
+With Livereload enabled, all the requests that return a response with a closing `body` tag will have the following injected into the HTML, right before `</body>`:
+```html
+<script src="//localhost:35729/livereload.js"></script>
+```
+
+If, for some reason, you need to change the URL, you can do so with the following configuration:
+```yml
+# app/config/config_dev.yml
+rj_frontend:
+    livereload:
+        url: //example.com:1234/livereload.js
+```
+
+> Note that the configuration should be added to `app/config/config_dev.yml` since it does not apply in other environments.
+
+If you wish to not have the livereload script injected, you can do so with the following configuration:
+```yml
+# app/config/config_dev.yml
+rj_frontend:
+    livereload: false
 ```
 
 # Overriding the default asset package

--- a/Resources/config/livereload.yml
+++ b/Resources/config/livereload.yml
@@ -1,5 +1,5 @@
 services:
     rj_frontend.livereload.listener:
-        class: Rj\FrontendBundle\EventListener\LiveReloadListener
+        class: Rj\FrontendBundle\EventListener\InjectLiveReloadListener
         tags:
             -  { name: kernel.event_subscriber }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -7,13 +7,13 @@ use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationTestCase;
 
 class ConfigurationTest extends AbstractConfigurationTestCase
 {
-    public function testLivereloadIsDisabledByDefault()
+    public function testLivereloadIsEnabledByDefault()
     {
         $this->assertConfigurationEquals(
             array(),
             array(
                 'livereload' => array(
-                    'enabled' => false,
+                    'enabled' => true,
                     'url' => '//localhost:35729/livereload.js',
                 ),
             ),
@@ -63,7 +63,7 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             'override_default_package' => true,
             'fallback_patterns' => array('.*bundles\/.*'),
             'livereload' => array(
-                'enabled' => false,
+                'enabled' => true,
                 'url' => '//localhost:35729/livereload.js',
             ),
             'prefix' => array('foo'),

--- a/Tests/DependencyInjection/RjFrontendExtensionTest.php
+++ b/Tests/DependencyInjection/RjFrontendExtensionTest.php
@@ -4,7 +4,7 @@ namespace Rj\FrontendBundle\Tests\DependencyInjection;
 
 class RjFrontendExtensionTest extends RjFrontendExtensionBaseTest
 {
-    public function testLivereloadListenerIsRegistered()
+    public function testInjectLivereloadListenerIsRegistered()
     {
         $this->load(array(
             'livereload' => array(
@@ -15,7 +15,7 @@ class RjFrontendExtensionTest extends RjFrontendExtensionBaseTest
 
         $this->assertContainerBuilderHasService(
             $this->namespaceService('livereload.listener'),
-            'Rj\FrontendBundle\EventListener\LiveReloadListener'
+            'Rj\FrontendBundle\EventListener\InjectLiveReloadListener'
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
@@ -25,7 +25,7 @@ class RjFrontendExtensionTest extends RjFrontendExtensionBaseTest
         );
     }
 
-    public function testLivereloadListenerIsNotRegistered()
+    public function testInjectLivereloadListenerIsNotRegistered()
     {
         $this->load(array('livereload' => false));
 

--- a/Tests/EventListener/InjectLiveReloadListenerTest.php
+++ b/Tests/EventListener/InjectLiveReloadListenerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Rj\FrontendBundle\Tests\EventListener;
+
+use Rj\FrontendBundle\EventListener\InjectLiveReloadListener;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class InjectLiveReloadListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDontInjectScriptIfNotMasterRequest()
+    {
+        $response = new Response('foo</body>');
+        $response->headers->set('X-Debug-Token', 'xxxxxxxx');
+
+        $listener = new InjectLiveReloadListener('bar');
+        $listener->onKernelResponse(new FilterResponseEvent(
+            $this->getKernelMock(),
+            $this->getRequestMock(),
+            HttpKernelInterface::SUB_REQUEST,
+            $response
+        ));
+
+        $this->assertEquals('foo</body>', $response->getContent());
+    }
+
+    public function testDontInjectScriptIfXmlHttpRequest()
+    {
+        $response = new Response('foo</body>');
+        $response->headers->set('X-Debug-Token', 'xxxxxxxx');
+
+        $listener = new InjectLiveReloadListener('bar');
+        $listener->onKernelResponse(new FilterResponseEvent(
+            $this->getKernelMock(),
+            $this->getRequestMock(true),
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        ));
+
+        $this->assertEquals('foo</body>', $response->getContent());
+    }
+
+    public function testDontInjectScriptIfXDebugTokenHeaderNotPresent()
+    {
+        $response = new Response('foo</body>');
+
+        $listener = new InjectLiveReloadListener('bar');
+        $listener->onKernelResponse(new FilterResponseEvent(
+            $this->getKernelMock(),
+            $this->getRequestMock(),
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        ));
+
+        $this->assertEquals('foo</body>', $response->getContent());
+    }
+
+    public function testDontInjectScriptIfNoClosingBodyTag()
+    {
+        $response = new Response('foo');
+        $response->headers->set('X-Debug-Token', 'xxxxxxxx');
+
+        $listener = new InjectLiveReloadListener('bar');
+        $listener->onKernelResponse(new FilterResponseEvent(
+            $this->getKernelMock(),
+            $this->getRequestMock(),
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        ));
+
+        $this->assertEquals('foo', $response->getContent());
+    }
+
+    public function testInjectScript()
+    {
+        $response = new Response('foo</body>');
+        $response->headers->set('X-Debug-Token', 'xxxxxxxx');
+
+        $listener = new InjectLiveReloadListener('bar');
+        $listener->onKernelResponse(new FilterResponseEvent(
+            $this->getKernelMock(),
+            $this->getRequestMock(),
+            HttpKernelInterface::MASTER_REQUEST,
+            $response
+        ));
+
+        $this->assertEquals('foo<script src="bar"></script></body>', $response->getContent());
+    }
+
+    protected function getRequestMock($isXmlHttpRequest = false)
+    {
+        $request = $this->getMock(
+            'Symfony\Component\HttpFoundation\Request',
+            array('isXmlHttpRequest'),
+            array(), '', false
+        );
+
+        $request->expects($this->any())
+            ->method('isXmlHttpRequest')
+            ->will($this->returnValue($isXmlHttpRequest));
+
+        return $request;
+    }
+
+    protected function getKernelMock()
+    {
+        return $this->getMock('Symfony\Component\HttpKernel\Kernel', array(), array(), '', false);
+    }
+}

--- a/Tests/Functional/InjectLivereloadTest.php
+++ b/Tests/Functional/InjectLivereloadTest.php
@@ -20,42 +20,4 @@ class InjectLivereloadTest extends BaseTestCase
         $response = $client->getResponse()->getContent();
         $this->assertEquals('foo</body>', $response);
     }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testInjectScript()
-    {
-        $client = $this->createClient(array(
-            'livereload' => array(
-                'url' => 'foo',
-            ),
-        ));
-
-        $router = $this->get('router');
-
-        $client->request('GET', $router->generate('livereload_inject'));
-
-        $response = $client->getResponse()->getContent();
-        $this->assertEquals('foo<script src="foo"></script></body>', $response);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
-    public function testNotInjectScript()
-    {
-        $client = $this->createClient(array(
-            'livereload' => array(
-                'url' => 'foo',
-            ),
-        ));
-
-        $router = $this->get('router');
-
-        $client->request('GET', $router->generate('livereload_not_inject'));
-
-        $response = $client->getResponse()->getContent();
-        $this->assertEquals('foo', $response);
-    }
 }

--- a/Tests/Functional/TestApp/TestBundle/Controller/InjectLivereloadController.php
+++ b/Tests/Functional/TestApp/TestBundle/Controller/InjectLivereloadController.php
@@ -11,9 +11,4 @@ class InjectLivereloadController extends Controller
     {
         return new Response('foo</body>');
     }
-
-    public function notInjectAction()
-    {
-        return new Response('foo');
-    }
 }

--- a/Tests/Functional/TestApp/app/config/routing.yml
+++ b/Tests/Functional/TestApp/app/config/routing.yml
@@ -2,10 +2,6 @@ livereload_inject:
     pattern:  /livereload/inject
     defaults: { _controller: TestBundle:InjectLivereload:inject }
 
-livereload_not_inject:
-    pattern:  /livereload/not_inject
-    defaults: { _controller: TestBundle:InjectLivereload:notInject }
-
 packages_custom:
     pattern:  /packages/custom
     defaults: { _controller: TestBundle:Packages:custom }


### PR DESCRIPTION
By using the X-Debug-Token header, inject the livereload script only in
development. By pairing this with enabling livereload by default in the
configuration we save one step in the bundle setup.

Transform functional livereload injection tests into unit tests.