### PR TITLE
Fix Symfony 3.4 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ install: ./.travis/install.php
 script: ./.travis/script.php
 after_script: ./.travis/after_script.php
 
+env:
+  global:
+    - SYMFONY_DEPRECATIONS_HELPER=weak
+
 matrix:
   include:
     # old PHP versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,19 @@ matrix:
     - php: 5.4
       env: SYMFONY_VERSION=2.8.* # Symfony 3 doesn't support PHP 5.4
     - php: 5.6
-      env: SYMFONY_VERSION=3.3.*
+      env: SYMFONY_VERSION=3.4.*
     # current PHP with all non-EOLed Symfony versions
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION=2.7.*
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION=2.8.*
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION=3.2.*
-    - php: 7.1
+    - php: 7.2
       env: SYMFONY_VERSION=3.3.*
-    - php: 7.1
+    - php: 7.2
+      env: SYMFONY_VERSION=3.4.*
+    - php: 7.2
       env: SYMFONY_VERSION=dev-master
   allow_failures:
     - env: SYMFONY_VERSION=dev-master

--- a/.travis/common.php
+++ b/.travis/common.php
@@ -12,12 +12,12 @@ function withCodeCoverage()
 
 function isLatestPhp()
 {
-    return getPhpVersion() === '7.1';
+    return getPhpVersion() === '7.2';
 }
 
 function isLatestSymfony()
 {
-    return getSymfonyVersion() === '3.3.*';
+    return getSymfonyVersion() === '3.4.*';
 }
 
 function getSymfonyVersion()

--- a/DependencyInjection/AssetExtensionLoader.php
+++ b/DependencyInjection/AssetExtensionLoader.php
@@ -4,9 +4,9 @@ namespace Rj\FrontendBundle\DependencyInjection;
 
 use Rj\FrontendBundle\Util\Util;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 
 class AssetExtensionLoader
@@ -76,8 +76,8 @@ class AssetExtensionLoader
         $isUrl = Util::containsUrl($prefixes);
 
         $packageDefinition = $isUrl
-            ? new DefinitionDecorator($this->namespaceService('asset.package.url'))
-            : new DefinitionDecorator($this->namespaceService('asset.package.path'))
+            ? new ChildDefinition($this->namespaceService('asset.package.url'))
+            : new ChildDefinition($this->namespaceService('asset.package.path'))
         ;
 
         if ($config['manifest']['enabled']) {
@@ -110,7 +110,7 @@ class AssetExtensionLoader
      */
     private function createManifestVersionStrategy($packageName, $config)
     {
-        $loader = new DefinitionDecorator($this->namespaceService('manifest.loader.'.$config['format']));
+        $loader = new ChildDefinition($this->namespaceService('manifest.loader.'.$config['format']));
         $loader
             ->addArgument($config['path'])
             ->addArgument($config['root_key'])
@@ -119,13 +119,13 @@ class AssetExtensionLoader
         $loaderId = $this->namespaceService("_package.$packageName.manifest_loader");
         $this->container->setDefinition($loaderId, $loader);
 
-        $cachedLoader = new DefinitionDecorator($this->namespaceService('manifest.loader.cached'));
+        $cachedLoader = new ChildDefinition($this->namespaceService('manifest.loader.cached'));
         $cachedLoader->addArgument(new Reference($loaderId));
 
         $cachedLoaderId = $this->namespaceService("_package.$packageName.manifest_loader_cached");
         $this->container->setDefinition($cachedLoaderId, $cachedLoader);
 
-        $versionStrategy = new DefinitionDecorator($this->namespaceService('version_strategy.manifest'));
+        $versionStrategy = new ChildDefinition($this->namespaceService('version_strategy.manifest'));
         $versionStrategy->addArgument(new Reference($cachedLoaderId));
 
         $versionStrategyId = $this->namespaceService("_package.$packageName.version_strategy");

--- a/DependencyInjection/AssetExtensionLoader.php
+++ b/DependencyInjection/AssetExtensionLoader.php
@@ -2,6 +2,13 @@
 
 namespace Rj\FrontendBundle\DependencyInjection;
 
+if (!class_exists('Symfony\Component\DependencyInjection\ChildDefinition')) {
+    class_alias(
+        'Symfony\Component\DependencyInjection\DefinitionDecorator',
+        'Symfony\Component\DependencyInjection\ChildDefinition'
+    );
+}
+
 use Rj\FrontendBundle\Util\Util;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
         $node = $this->createRoot('prefix')
             ->prototype('scalar')->end()
             ->defaultValue([$defaultValue])
-            ->cannotBeEmpty()
+            ->requiresAtLeastOneElement()
             ->beforeNormalization()
                 ->ifString()
                 ->then(function ($v) { return [$v]; })

--- a/DependencyInjection/RjFrontendExtension.php
+++ b/DependencyInjection/RjFrontendExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\Kernel;
 
 class RjFrontendExtension extends Extension
 {
@@ -21,6 +22,10 @@ class RjFrontendExtension extends Extension
         $loader->load('console.yml');
         $loader->load('version_strategy.yml');
         $loader->load('manifest.yml');
+
+        if (version_compare(Kernel::VERSION, '3.3.0', '>=')) {
+            $loader->load('commands.yml');
+        }
 
         if ($config['livereload']['enabled']) {
             $loader->load('livereload.yml');

--- a/Resources/config/commands.yml
+++ b/Resources/config/commands.yml
@@ -1,0 +1,5 @@
+services:
+    Rj\FrontendBundle\Command\:
+        resource: '../../Command/*Command.php'
+        tags:
+            -  { name: console.command }

--- a/Tests/Command/SetupCommandTest.php
+++ b/Tests/Command/SetupCommandTest.php
@@ -282,8 +282,7 @@ class SetupCommandTest extends \PHPUnit_Framework_TestCase
 
         // Simulate the user pressing enter. This is needed to test the default
         // value, has no impact when the value is provided.
-        $helper = $this->command->getHelper('question');
-        $helper->setInputStream($this->getInputStream(PHP_EOL));
+        $this->commandTester->setInputs([PHP_EOL]);
 
         $this->commandTester->execute($options, [
             'interactive' => $interactive,
@@ -292,19 +291,5 @@ class SetupCommandTest extends \PHPUnit_Framework_TestCase
         foreach ($expected as $key => $value) {
             $this->assertEquals($value, $this->commandTester->getInput()->getOption($key));
         }
-    }
-
-    /**
-     * @param $input
-     *
-     * @return bool|resource
-     */
-    private function getInputStream($input)
-    {
-        $stream = fopen('php://memory', 'r+', false);
-        fputs($stream, $input);
-        rewind($stream);
-
-        return $stream;
     }
 }

--- a/Tests/Command/SetupCommandTest.php
+++ b/Tests/Command/SetupCommandTest.php
@@ -282,7 +282,14 @@ class SetupCommandTest extends \PHPUnit_Framework_TestCase
 
         // Simulate the user pressing enter. This is needed to test the default
         // value, has no impact when the value is provided.
-        $this->commandTester->setInputs([PHP_EOL]);
+        if (method_exists($this->commandTester, 'setInputs')) {
+            $this->commandTester->setInputs([PHP_EOL]);
+        } else {
+            $stream = fopen('php://memory', 'r+', false);
+            fputs($stream, PHP_EOL);
+            rewind($stream);
+            $this->command->getHelper('question')->setInputStream($stream);
+        }
 
         $this->commandTester->execute($options, [
             'interactive' => $interactive,

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,8 @@
         "symfony/browser-kit": "^2.7|~3.0",
         "symfony/filesystem": "~2.7|~3.0",
         "symfony/http-foundation": "~2.7|~3.0",
-        "symfony/routing": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/routing": "~2.7|~3.0",
+        "symfony/var-dumper": "~2.7|~3.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,8 +14,6 @@
                 <directory>./vendor</directory>
                 <directory>./Tests</directory>
                 <directory>./Resources</directory>
-                <directory>./Asset</directory>
-                <directory>./Command/Options/Legacy</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,4 +19,8 @@
             </exclude>
         </whitelist>
     </filter>
+    <php>
+        <!-- See https://github.com/symfony/symfony/issues/25362 -->
+        <env name="SHELL_VERBOSITY" value="1"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
Fixes #33 

This PR does not introduce support for the new directory structure introduced in Symfony 3.4, it merely fixes deprecations. The new directory structure will be addressed in another PR.